### PR TITLE
feat: add version field to showcase-ecommerce index.json

### DIFF
--- a/datapacks/showcase-ecommerce/index.json
+++ b/datapacks/showcase-ecommerce/index.json
@@ -1,1 +1,7 @@
-{"files": [{"path": "01-definitions.json", "wait_for_completion": true}, {"path": "02-data.json"}]}
+{
+  "version": "2",
+  "files": [
+    {"path": "01-definitions.json", "wait_for_completion": true},
+    {"path": "02-data.json"}
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a `version` field to `index.json` for cache invalidation support.

```json
{
  "version": "2",
  "files": [...]
}
```

Companion to datahub-project/datahub#16869 which adds version-based cache checking to the CLI. When a pack maintainer bumps the version, clients automatically re-download data files on next load.

Set to `"2"` to reflect the data fixes in PR #191 (termSource + empty aspects).