### PR TITLE
fix(datapacks): CAT-2450 remove invalid prefix from dataHubRole

### DIFF
--- a/datapacks/showcase-ecommerce/02-data.json
+++ b/datapacks/showcase-ecommerce/02-data.json
@@ -2268,7 +2268,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Editor"
+          "urn:li:dataHubRole:Editor"
         ]
       }
     },
@@ -2487,7 +2487,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Admin"
+          "urn:li:dataHubRole:Admin"
         ]
       }
     },
@@ -2615,7 +2615,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Admin"
+          "urn:li:dataHubRole:Admin"
         ]
       }
     },
@@ -2774,7 +2774,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Admin"
+          "urn:li:dataHubRole:Admin"
         ]
       }
     },
@@ -2928,7 +2928,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Admin"
+          "urn:li:dataHubRole:Admin"
         ]
       }
     },
@@ -3067,7 +3067,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Admin"
+          "urn:li:dataHubRole:Admin"
         ]
       }
     },
@@ -3413,7 +3413,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Admin"
+          "urn:li:dataHubRole:Admin"
         ]
       }
     },
@@ -3576,7 +3576,7 @@
     "aspect": {
       "json": {
         "roles": [
-          "urn:li:dataHubRole:b2fd91.Admin"
+          "urn:li:dataHubRole:Admin"
         ]
       }
     },

--- a/datapacks/showcase-ecommerce/index.json
+++ b/datapacks/showcase-ecommerce/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "3",
+  "version": "4",
   "files": [
     {"path": "01-definitions.json", "wait_for_completion": true},
     {"path": "02-data.json"},


### PR DESCRIPTION
Similar to CAT-2446 where dataHubRole was being exported with a prefix. Roles are internal/fixed/system names, so this created a dangling role, which broke the users page when an impacted user record was loaded.