### PR TITLE
fix(nyc-taxi): match instance name exactly to avoid prefix collision

### DIFF
--- a/datasets/nyc-taxi/add_lineage.py
+++ b/datasets/nyc-taxi/add_lineage.py
@@ -76,7 +76,8 @@ def discover_urns(graph, platform_instance):
         name = entity.get("name", "")
         if entity.get("platform", {}).get("name", "") != PLATFORM:
             continue
-        if platform_instance not in urn:
+        # exact-instance match: ",nyc_taxi." must not match ",nyc_taxi_pipeline." (prefix collision)
+        if f",{platform_instance}." not in urn:
             continue
         simple_name = name.split(".")[-1] if "." in name else name
         urn_map[simple_name] = urn

--- a/datasets/nyc-taxi/add_metadata.py
+++ b/datasets/nyc-taxi/add_metadata.py
@@ -101,7 +101,8 @@ def discover_urns(graph, platform_instance):
         entity = item.get("entity", {})
         if entity.get("platform", {}).get("name", "") != PLATFORM:
             continue
-        if platform_instance not in entity.get("urn", ""):
+        # exact-instance match: ",nyc_taxi." must not match ",nyc_taxi_pipeline." (prefix collision)
+        if f",{platform_instance}." not in entity.get("urn", ""):
             continue
         name = entity.get("name", "")
         simple = name.split(".")[-1] if "." in name else name


### PR DESCRIPTION
### TL;DR

The instance filter uses a substring test, which collides when one instance
name is a prefix of another (`"nyc_taxi"` ⊂ `"nyc_taxi_pipeline"`). Fixed by
matching the exact instance name.

![Bug fix diagram: instance-name prefix collision](https://raw.githubusercontent.com/yanou16/static-assets/pr-213-assets/pr213-diagram.png)

### Problem

The nyc-taxi helper scripts filter discovered dataset URNs by instance using a
plain substring test:

```python
if platform_instance not in urn:      # add_lineage.py
if platform_instance not in entity.get("urn", ""):   # add_metadata.py
```

This is wrong when one instance name is a prefix of another. The dataset
ships two instances, `nyc_taxi` and `nyc_taxi_pipeline`, and `"nyc_taxi"` is a
substring of `"nyc_taxi_pipeline"`. So when running for `--instance=nyc_taxi`,
the filter also lets `nyc_taxi_pipeline` URNs through. Same-named tables
(`staging_trips`, `mart_daily_summary`, ...) then overwrite each other in
`urn_map`, and lineage/metadata for the clean `nyc_taxi` instance gets emitted
onto `nyc_taxi_pipeline` URNs — leaving the `nyc_taxi` instance with no lineage.

### Fix

Match the exact instance by checking for `",{instance}."`. Inside a dataset URN
the instance name is delimited by a comma and a dot
(`...,nyc_taxi.main.staging_trips,...`), so `",nyc_taxi."` does not match
`",nyc_taxi_pipeline."`. Applied in both `add_lineage.py` and `add_metadata.py`.

### Impact

- `datahub ... add_lineage.py --instance=nyc_taxi` / `--all` now writes lineage
  to the correct instance.
- No behavior change for single-instance users or for `nyc_taxi_pipeline`.

### How to reproduce (before the fix)

```bash
python add_lineage.py --all
# then query lineage for nyc_taxi.staging_trips -> 0 downstream (should be 4)
```
