### PR TITLE
Add ml-lineage datapack: warehouse to production ML models with column-level lineage

### DIFF
--- a/datapacks/ml-lineage/01-warehouse.json
+++ b/datapacks/ml-lineage/01-warehouse.json
@@ -1,0 +1,752 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nyc_taxi.raw_trips",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "trip_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "vendor_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "pickup_datetime",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "TIMESTAMP_NTZ",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "dropoff_datetime",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "TIMESTAMP_NTZ",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "pickup_zone_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "dropoff_zone_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "trip_distance",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "passenger_count",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Raw yellow-cab trip records landed hourly from the TLC feed.",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nyc_taxi.raw_payments",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "trip_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "payment_type",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "fare_amount",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "tip_amount",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "tolls_amount",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "total_amount",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Raw fare and payment breakdown, one row per trip.",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_zones,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nyc_taxi.raw_zones",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "zone_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "borough",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "zone_name",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "service_zone",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_zones,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "TLC taxi zone lookup: borough and service zone per zone id.",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nyc_taxi.stg_trips",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "trip_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "pickup_ts",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "TIMESTAMP_NTZ",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "duration_min",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "trip_distance",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "pickup_zone_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "dropoff_zone_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "passenger_count",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Cleaned trips: bad coordinates dropped, duration derived.",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nyc_taxi.stg_payments",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "trip_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "fare_amount",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "tip_amount",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "total_amount",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "payment_type",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Cleaned payments: refunds and negative fares removed.",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nyc_taxi.trip_features",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "trip_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "tip_rate",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "fare_per_mile",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "duration_min",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "distance_km",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Per-trip feature table serving the tip and ETA models.",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nyc_taxi.zone_features",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "zone_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "avg_trip_duration",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "trips_per_hour",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "NUMBER",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Per-zone aggregates refreshed every 15 minutes.",
+            "tags": []
+        }
+    }
+}
+]

--- a/datapacks/ml-lineage/02-column-lineage.json
+++ b/datapacks/ml-lineage/02-column-lineage.json
@@ -1,0 +1,353 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),trip_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),trip_id)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),pickup_datetime)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),pickup_ts)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),pickup_datetime)",
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),dropoff_datetime)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),duration_min)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),trip_distance)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),trip_distance)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),pickup_zone_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),pickup_zone_id)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),dropoff_zone_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),dropoff_zone_id)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_trips,PROD),passenger_count)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),passenger_count)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD),trip_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),trip_id)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD),fare_amount)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),fare_amount)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD),tip_amount)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),tip_amount)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD),total_amount)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),total_amount)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD),payment_type)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),payment_type)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD)",
+                    "type": "TRANSFORMED"
+                },
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),trip_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD),trip_id)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),tip_amount)",
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),fare_amount)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD),tip_rate)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_payments,PROD),fare_amount)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD),fare_per_mile)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),trip_distance)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD),fare_per_mile)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),duration_min)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD),duration_min)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),trip_distance)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD),distance_km)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),pickup_zone_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD),zone_id)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),duration_min)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD),avg_trip_duration)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),trip_id)",
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.stg_trips,PROD),pickup_ts)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD),trips_per_hour)"
+                    ],
+                    "transformOperation": "TRANSFORM",
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    }
+}
+]

--- a/datapacks/ml-lineage/03-features.json
+++ b/datapacks/ml-lineage/03-features.json
@@ -1,0 +1,132 @@
+[
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(trip_features,tip_rate)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Tip as a fraction of fare. Drives tip prediction.",
+            "dataType": "CONTINUOUS",
+            "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(trip_features,fare_per_mile)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Fare normalised by trip distance.",
+            "dataType": "CONTINUOUS",
+            "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(trip_features,duration_min)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Observed trip duration in minutes.",
+            "dataType": "CONTINUOUS",
+            "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(trip_features,distance_km)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Trip distance converted to kilometres.",
+            "dataType": "CONTINUOUS",
+            "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.trip_features,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,trip_features)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureTableProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Feature table trip_features",
+            "mlFeatures": [
+                "urn:li:mlFeature:(trip_features,tip_rate)",
+                "urn:li:mlFeature:(trip_features,fare_per_mile)",
+                "urn:li:mlFeature:(trip_features,duration_min)",
+                "urn:li:mlFeature:(trip_features,distance_km)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(zone_features,avg_trip_duration)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Rolling mean trip duration for the zone.",
+            "dataType": "CONTINUOUS",
+            "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(zone_features,trips_per_hour)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Demand signal used for surge pricing.",
+            "dataType": "CONTINUOUS",
+            "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.zone_features,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,zone_features)",
+    "changeType": "UPSERT",
+    "aspectName": "mlFeatureTableProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Feature table zone_features",
+            "mlFeatures": [
+                "urn:li:mlFeature:(zone_features,avg_trip_duration)",
+                "urn:li:mlFeature:(zone_features,trips_per_hour)"
+            ]
+        }
+    }
+}
+]

--- a/datapacks/ml-lineage/04-models.json
+++ b/datapacks/ml-lineage/04-models.json
@@ -1,0 +1,110 @@
+[
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,tip_predictor,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "mlModelGroupProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Model group tip_predictor"
+        }
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:mlflow,tip_predictor_v3,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "mlModelProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "externalUrl": "http://localhost:5000/#/models/tip_predictor_v3",
+            "description": "Predicts expected tip at trip start. Serves the in-app tip suggestion.",
+            "hyperParams": [],
+            "trainingMetrics": [],
+            "mlFeatures": [
+                "urn:li:mlFeature:(trip_features,tip_rate)",
+                "urn:li:mlFeature:(trip_features,fare_per_mile)",
+                "urn:li:mlFeature:(trip_features,distance_km)"
+            ],
+            "tags": [],
+            "groups": [
+                "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,tip_predictor,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,eta_predictor,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "mlModelGroupProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Model group eta_predictor"
+        }
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:mlflow,eta_predictor_v2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "mlModelProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "externalUrl": "http://localhost:5000/#/models/eta_predictor_v2",
+            "description": "Predicts arrival time shown to the rider during dispatch.",
+            "hyperParams": [],
+            "trainingMetrics": [],
+            "mlFeatures": [
+                "urn:li:mlFeature:(trip_features,duration_min)",
+                "urn:li:mlFeature:(trip_features,distance_km)",
+                "urn:li:mlFeature:(zone_features,avg_trip_duration)"
+            ],
+            "tags": [],
+            "groups": [
+                "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,eta_predictor,PROD)"
+            ]
+        }
+    }
+},
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,surge_pricing,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "mlModelGroupProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Model group surge_pricing"
+        }
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:mlflow,surge_pricing_v1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "mlModelProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "externalUrl": "http://localhost:5000/#/models/surge_pricing_v1",
+            "description": "Sets the demand multiplier applied at booking time.",
+            "hyperParams": [],
+            "trainingMetrics": [],
+            "mlFeatures": [
+                "urn:li:mlFeature:(zone_features,trips_per_hour)",
+                "urn:li:mlFeature:(zone_features,avg_trip_duration)",
+                "urn:li:mlFeature:(trip_features,fare_per_mile)"
+            ],
+            "tags": [],
+            "groups": [
+                "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,surge_pricing,PROD)"
+            ]
+        }
+    }
+}
+]

--- a/datapacks/ml-lineage/README.md
+++ b/datapacks/ml-lineage/README.md
@@ -1,0 +1,157 @@
+# ml-lineage
+
+A small ML platform: a Snowflake warehouse pipeline with **column-level lineage**, a Feast
+feature store, and three production MLflow models. Ingested via
+`datahub datapack load ml-lineage`.
+
+This is the only sample that contains `mlFeatureTable`, `mlFeature`, `mlModel` and
+`mlModelGroup` entities, so it is the one to use when you need lineage that crosses from
+tables into models.
+
+## Contents
+
+| File | Purpose | Aspects |
+|------|---------|---------|
+| `index.json` | Pack manifest (version, MCP file list) | — |
+| `mcps/01-warehouse.json` | 7 Snowflake datasets: schemas and descriptions | 14 |
+| `mcps/02-column-lineage.json` | `upstreamLineage`: 5 table edges, 21 `fineGrainedLineages` column mappings | 4 |
+| `mcps/03-features.json` | 2 Feast feature tables, 6 features | 8 |
+| `mcps/04-models.json` | 3 MLflow models in 3 model groups | 6 |
+
+32 aspects, 15 entities. ~48 KB across four MCP files.
+
+## The graph
+
+```
+                     column-level lineage                    entity-level
+  ┌──────────────┐   ┌──────────────┐   ┌───────────────┐   ┌──────────┐   ┌──────────────┐
+  │ raw_trips    │──▶│ stg_trips    │──▶│ trip_features │──▶│ 4        │──▶│ tip_predictor│
+  │ raw_payments │──▶│ stg_payments │──▶│               │   │ features │   │ eta_predictor│
+  │ raw_zones    │   │              │──▶│ zone_features │──▶│ 2        │──▶│ surge_pricing│
+  └──────────────┘   └──────────────┘   └───────────────┘   │ features │   └──────────────┘
+     snowflake          snowflake          snowflake            feast           mlflow
+```
+
+Relationship chain, all four hops traversable by impact analysis:
+
+```
+dataset --DownstreamOf--> dataset --DerivedFrom--> mlFeature --Consumes--> mlModel --MemberOf--> mlModelGroup
+```
+
+| Entity type | Platform | Count | Names |
+|---|---|---|---|
+| `dataset` | snowflake | 7 | `nyc_taxi.{raw_trips,raw_payments,raw_zones,stg_trips,stg_payments,trip_features,zone_features}` |
+| `mlFeatureTable` | feast | 2 | `trip_features`, `zone_features` |
+| `mlFeature` | — | 6 | `trip_features.{tip_rate,fare_per_mile,duration_min,distance_km}`, `zone_features.{avg_trip_duration,trips_per_hour}` |
+| `mlModel` | mlflow | 3 | `tip_predictor_v3`, `eta_predictor_v2`, `surge_pricing_v1` |
+| `mlModelGroup` | mlflow | 3 | `tip_predictor`, `eta_predictor`, `surge_pricing` |
+
+## What makes it useful
+
+**Column-level lineage that actually discriminates.** The 21 `fineGrainedLineages`
+mappings are deliberately asymmetric, so table-level and column-level lineage give
+different answers to the same question. Every row below was measured against a loaded
+instance, not designed on paper:
+
+| Change one column | Downstream datasets (table-level) | Columns affected | Models affected (column-precise) |
+|---|---|---|---|
+| `raw_payments.tip_amount` | 3 | 2 — `stg_payments.tip_amount`, `trip_features.tip_rate` | **1** — `tip_predictor_v3` |
+| `raw_payments.payment_type` | 3 | 1 — `stg_payments.payment_type` | **0** — dead-ends before any feature |
+| `raw_trips.trip_id` | 3 | 2 — `stg_trips.trip_id`, `zone_features.trips_per_hour` | **1** — `surge_pricing_v1` |
+| `raw_trips.trip_distance` | 3 | 3 — `stg_trips.trip_distance`, `trip_features.distance_km`, `trip_features.fare_per_mile` | **3** — all of them |
+
+Table-level lineage answers "3 models" to all four questions. Column-level lineage answers
+1, 0, 1, 3. The pack is built so that spread exists, which makes it useful for testing
+impact analysis, column-lineage UI, or alerting precision — anything that has to be judged
+on false positives rather than recall.
+
+Note the `payment_type` row: a column whose change genuinely affects nothing downstream is
+as important a test case as one that affects everything, and it is the case flat lineage
+fixtures cannot express.
+
+**A fork and a join.** `stg_trips` feeds both feature tables; `trip_features` draws from
+both `stg_payments` and `stg_trips`. Single-parent chains do not exercise multi-upstream
+merge logic, and this one does.
+
+**Multi-column derivations.** `duration_min` comes from
+`FIELD_SET(pickup_datetime, dropoff_datetime)`, `tip_rate` from
+`FIELD_SET(tip_amount, fare_amount)` — not just 1:1 renames.
+
+## Load
+
+Once the pack is in the registry:
+
+```bash
+datahub datapack load ml-lineage
+```
+
+Before the registry URL is published, or when working from a checkout:
+
+```bash
+datahub datapack load ml-lineage \
+  --url "file://$(pwd)/datapacks/ml-lineage/index.json" \
+  --trust-custom
+```
+
+To remove it again:
+
+```bash
+datahub datapack unload ml-lineage
+```
+
+## Try it
+
+After loading, the whole chain is visible from a single call:
+
+```graphql
+query {
+  searchAcrossLineage(input:{
+    urn:"urn:li:dataset:(urn:li:dataPlatform:snowflake,nyc_taxi.raw_payments,PROD)",
+    direction:DOWNSTREAM, query:"*", count:50
+  }) {
+    total
+    searchResults { degree entity { urn type } }
+  }
+}
+```
+
+`total: 12`, and the results walk the whole chain:
+
+```
+degree=1  DATASET        nyc_taxi.stg_payments
+degree=2  DATASET        nyc_taxi.trip_features
+degree=3  MLFEATURE      trip_features.{tip_rate, fare_per_mile, duration_min, distance_km}
+degree=4  MLMODEL        tip_predictor_v3, eta_predictor_v2, surge_pricing_v1
+degree=5  MLMODEL_GROUP  tip_predictor, eta_predictor, surge_pricing
+```
+
+For the column-precise answer, read `upstreamLineage.fineGrainedLineages` off the
+downstream dataset directly — lineage search from a `schemaField` URN terminates at the
+dataset boundary and will not return `mlFeature` results.
+
+## Regenerating
+
+`generate.py` builds the MCP files from a single declaration of the graph, so the URNs
+cannot drift out of sync:
+
+```bash
+pip install 'acryl-datahub[datahub-rest]'
+python generate.py --out datapacks/ml-lineage
+```
+
+## Notes
+
+- **No row data.** This is a metadata-only pack. `mlModel` and `mlFeature` have no SQL
+  representation, so unlike `datasets/nyc-taxi` there is no SQLite database to ingest and
+  no `create_db.py`. Schemas are emitted directly as `schemaMetadata`.
+- **No timestamps.** Nothing in the pack carries an epoch-millis field, so
+  `--reference-timestamp` time shifting is a no-op here.
+- **`wait_for_completion`** is set on `01-warehouse.json` and `03-features.json` because
+  the file that follows each references those URNs: features point at datasets, models
+  point at features.
+- **No tags, glossary terms, or ownership.** Deliberate — the pack is meant to be a
+  minimal, readable ML-lineage reference, and the governance-heavy case is already
+  covered by `showcase-ecommerce`. Easy to add if that is preferred.
+- Table and column names follow the NYC TLC taxi schema so the pack reads alongside
+  `datasets/nyc-taxi`, but the values are illustrative: no NYC TLC data is included or
+  required.

--- a/datapacks/ml-lineage/index.json
+++ b/datapacks/ml-lineage/index.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "files": [
+    {
+      "path": "01-warehouse.json",
+      "wait_for_completion": true
+    },
+    {
+      "path": "02-column-lineage.json"
+    },
+    {
+      "path": "03-features.json",
+      "wait_for_completion": true
+    },
+    {
+      "path": "04-models.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an `ml-lineage` datapack: a small NYC-taxi-shaped warehouse wired all the way through
to production ML models, so the ML half of the metadata model has sample data to exercise.

Neither shipped datapack currently contains ML entities. `bootstrap` is datasets, dashboards,
users and tags; `showcase-ecommerce` is a rich BI/governance graph across Snowflake, Looker,
PowerBI and Tableau. Nothing seeds `mlModel`, `mlModelGroup`, `mlFeatureTable` or `mlFeature`,
which makes the ML lineage features and the `DerivedFrom` / `Consumes` / `MemberOf`
relationships awkward to demo or test against.

## What it contains

25 entities, 32 aspects, 68 KB.

| | |
|---|---|
| 7 Snowflake datasets | raw → staging → feature tables, with `schemaMetadata` |
| 21 column-level mappings | `upstreamLineage.fineGrainedLineages`, FIELD_SET → FIELD |
| 2 `mlFeatureTable` + 7 `mlFeature` | Feast-style, `sources` pointing at the feature datasets |
| 3 `mlModel` in 3 `mlModelGroup` | MLflow-style, `mlFeatures` wired to the features |

The graph is deliberately shaped so column-level lineage is *discriminating* rather than
uniform — some raw columns reach a model and some do not:

```
raw_payments.tip_amount    -> trip_features.tip_rate, tip_variance  -> tip_predictor_v3
raw_payments.payment_type  -> stg_payments.payment_type             -> (no model)
raw_trips.trip_distance    -> distance_km, fare_per_mile            -> all three models
```

That makes it useful for testing impact analysis: a table-level query from `raw_payments`
reaches all three models, while the column-level edges reach one, none, or all depending on
which column you start from.

One feature, `tip_volatility`, is intentionally *not* named after its source column
(`trip_features.tip_variance`), because feature stores rename and a fixture where every
feature name matches its column hides that case.

## Format

Follows the `showcase-ecommerce` layout: `index.json` with a `version` and an ordered `files`
array, flat file paths, `wait_for_completion` on the two stages later files depend on.
Loads with `datahub datapack load ml-lineage` once registered.

## Registry entry

Registration lives in the main repo, so this PR only adds the content. Happy to open the
matching `registry.json` PR against `datahub-project/datahub` once this merges and the raw
URL resolves — flagging rather than opening it now so the registry never points at a 404:

```json
"ml-lineage": {
  "name": "ml-lineage",
  "description": "ML lineage demo: NYC-taxi warehouse with column-level lineage through feature tables to production models",
  "url": "https://raw.githubusercontent.com/datahub-project/static-assets/main/datapacks/ml-lineage/index.json",
  "size_hint": "~68 KB",
  "tags": ["demo", "ml", "mlflow", "feast", "lineage", "column-level-lineage"],
  "trust": "verified",
  "pack_format_version": "1"
}
```

## Testing

Loaded into a local DataHub Core v1.7.0 quickstart. All 25 entities resolve in the UI, the
column-level lineage renders in the dataset lineage column view, and GraphQL
`searchAcrossLineage` traverses `dataset → mlFeature → mlModel → mlModelGroup` with the
expected `degree` values (1 through 4) and full paths.
