### PR TITLE
fix(nyc-taxi): make planted freshness defects deterministic

### DIFF
--- a/datasets/nyc-taxi/README.md
+++ b/datasets/nyc-taxi/README.md
@@ -93,17 +93,21 @@ Same 3-stage pipeline structure, but with freshness issues planted:
 
 | Issue | What's Planted | How to Detect |
 |---|---|---|
-| Stale staging | `staging_trips` stops 3 days before `raw_trips` max date | Compare `MAX(trip_date)` between raw and staging |
-| Stale mart | `mart_daily_summary` reflects the staging gap | Last 3 days missing from daily summary |
+| Stale staging | Rows after a cutoff 3 calendar days before the raw max are removed. Because the committed subset has sparse dates, its latest remaining staging date is 9 days behind raw. | Compare raw pickup date max with `MAX(trip_date)` in staging |
+| Stale mart | `mart_daily_summary` reflects the same cutoff and observed 9-day gap in the committed subset | Compare raw and mart business-date maxima |
 | Empty load | One day in the mart shows 0 trips | `trip_count = 0` for that day — pipeline ran but loaded nothing |
 
 **The core trick:** DataHub metadata shows all tables as "ingested now" (because they were all ingested at the same time). The staleness is invisible in metadata — you can only detect it by querying the actual data timestamps.
 
 ```
-raw_trips:          data through Jan 31  ← looks fresh
-staging_trips:      data through Jan 28  ← 3 days behind (stale!)
-mart_daily_summary: data through Jan 28  ← also stale, plus one day shows 0 trips
+raw_trips:          data through Mar 10  ← looks fresh
+staging_trips:      data through Mar 01  ← 9 observed days behind (stale!)
+mart_daily_summary: data through Mar 01  ← also stale; Jan 21 shows 0 trips
 ```
+
+`create_db.py` derives the cutoff from the raw pickup timestamp and reports the
+actual observed lag after applying it. This distinction matters for a sampled
+database where not every calendar date has rows.
 
 ---
 

--- a/datasets/nyc-taxi/create_db.py
+++ b/datasets/nyc-taxi/create_db.py
@@ -248,46 +248,84 @@ def create_views(conn, pickup_col, dropoff_col):
 def plant_staleness(conn):
     """Plant freshness issues into the pipeline.
 
-    The core trick: raw_trips has data through the latest date,
-    but staging_trips and mart_daily_summary stop 3 days earlier.
+    The core trick: raw_trips has data through the latest date, while
+    staging_trips and mart_daily_summary use a cutoff 3 calendar days earlier.
+    With a sparse source sample, the latest remaining stage date can be older
+    than that cutoff.
 
     This simulates a pipeline that ran successfully (DataHub shows
     "ingested now") but didn't actually process new data.
     """
-    max_raw = conn.execute("SELECT MAX(trip_date) FROM staging_trips").fetchone()[0]
+    raw_columns = [row[1] for row in conn.execute("PRAGMA table_info(raw_trips)")]
+    pickup_col, _ = detect_datetime_columns(raw_columns)
+    if not pickup_col:
+        print("    ✗ Cannot find pickup datetime column in raw_trips — skipping")
+        return
+
+    quoted_pickup_col = pickup_col.replace('"', '""')
+    max_raw = conn.execute(
+        f'SELECT MAX(DATE("{quoted_pickup_col}")) FROM raw_trips'
+    ).fetchone()[0]
     if not max_raw:
         print("    ✗ Cannot determine max date — skipping")
         return
 
-    cutoff_date = (datetime.strptime(max_raw, "%Y-%m-%d") - timedelta(days=3)).strftime("%Y-%m-%d")
+    cutoff_date = (
+        datetime.strptime(max_raw, "%Y-%m-%d") - timedelta(days=3)
+    ).strftime("%Y-%m-%d")
     print(f"    Raw data through: {max_raw}")
-    print(f"    Staging/mart cutoff: {cutoff_date} (3 days stale)")
+    print(f"    Staging/mart cutoff target: {cutoff_date} (3 calendar days)")
 
     # Remove recent rows from staging
     before = conn.execute("SELECT COUNT(*) FROM staging_trips").fetchone()[0]
-    conn.execute(f"DELETE FROM staging_trips WHERE trip_date > '{cutoff_date}'")
+    conn.execute("DELETE FROM staging_trips WHERE trip_date > ?", (cutoff_date,))
     after = conn.execute("SELECT COUNT(*) FROM staging_trips").fetchone()[0]
     print(f"    ✓ staging_trips: removed {before - after:,} recent rows")
 
     # Remove recent days from mart
     before_m = conn.execute("SELECT COUNT(*) FROM mart_daily_summary").fetchone()[0]
-    conn.execute(f"DELETE FROM mart_daily_summary WHERE trip_date > '{cutoff_date}'")
+    conn.execute("DELETE FROM mart_daily_summary WHERE trip_date > ?", (cutoff_date,))
     after_m = conn.execute("SELECT COUNT(*) FROM mart_daily_summary").fetchone()[0]
     print(f"    ✓ mart_daily_summary: removed {before_m - after_m} recent days")
 
-    # Plant one "empty load" day (pipeline ran, loaded nothing)
-    mid_date = (datetime.strptime(cutoff_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
-    conn.execute(f"""
-        UPDATE mart_daily_summary
-        SET trip_count = 0, total_fare = 0, total_revenue = 0,
-            avg_fare = 0, avg_distance = 0, avg_passengers = 0, avg_duration_min = 0
-        WHERE trip_date = '{mid_date}'
-    """)
-    affected = conn.execute("SELECT changes()").fetchone()[0]
+    stage_max = conn.execute("SELECT MAX(trip_date) FROM staging_trips").fetchone()[0]
+    if stage_max:
+        actual_lag = (
+            datetime.strptime(max_raw, "%Y-%m-%d")
+            - datetime.strptime(stage_max, "%Y-%m-%d")
+        ).days
+        print(
+            f"    Observed staging max: {stage_max} "
+            f"({actual_lag} calendar days behind raw)"
+        )
+
+    # Plant one "empty load" on an existing mart day. Selecting the median
+    # remaining date makes this deterministic even when the sample has gaps.
+    mart_dates = [
+        row[0]
+        for row in conn.execute(
+            "SELECT trip_date FROM mart_daily_summary "
+            "WHERE COALESCE(trip_count, 0) <> 0 ORDER BY trip_date"
+        )
+    ]
+    mid_date = mart_dates[len(mart_dates) // 2] if mart_dates else None
+    affected = 0
+    if mid_date is not None:
+        conn.execute(
+            """
+            UPDATE mart_daily_summary
+            SET trip_count = 0, total_fare = 0, total_revenue = 0,
+                avg_fare = 0, avg_distance = 0,
+                avg_passengers = 0, avg_duration_min = 0
+            WHERE trip_date = ?
+            """,
+            (mid_date,),
+        )
+        affected = conn.execute("SELECT changes()").fetchone()[0]
     if affected > 0:
         print(f"    ✓ Empty load: {mid_date} shows 0 trips (pipeline ran but loaded nothing)")
     else:
-        print(f"    ⚠ Empty load: {mid_date} not found in mart (skipped)")
+        print("    ⚠ Empty load: no eligible mart date found (skipped)")
 
     conn.commit()
 

--- a/tests/test_nyc_taxi_create_db.py
+++ b/tests/test_nyc_taxi_create_db.py
@@ -1,0 +1,77 @@
+import importlib.util
+import sqlite3
+import unittest
+from pathlib import Path
+
+
+CREATE_DB_PATH = (
+    Path(__file__).resolve().parents[1] / "datasets" / "nyc-taxi" / "create_db.py"
+)
+SPEC = importlib.util.spec_from_file_location("nyc_taxi_create_db", CREATE_DB_PATH)
+assert SPEC is not None and SPEC.loader is not None
+CREATE_DB = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CREATE_DB)
+
+
+class PlantStalenessTest(unittest.TestCase):
+    def make_pipeline(self):
+        conn = sqlite3.connect(":memory:")
+        self.addCleanup(conn.close)
+        conn.executescript(
+            """
+            CREATE TABLE raw_trips (tpep_pickup_datetime TEXT);
+            CREATE TABLE staging_trips (trip_date TEXT);
+            CREATE TABLE mart_daily_summary (
+                trip_date TEXT,
+                trip_count INTEGER,
+                total_fare REAL,
+                total_revenue REAL,
+                avg_fare REAL,
+                avg_distance REAL,
+                avg_passengers REAL,
+                avg_duration_min REAL
+            );
+            """
+        )
+
+        raw_dates = [f"2026-01-{day:02d} 12:00:00" for day in range(1, 11)]
+        staging_dates = [f"2026-01-{day:02d}" for day in range(1, 10)]
+        conn.executemany("INSERT INTO raw_trips VALUES (?)", [(d,) for d in raw_dates])
+        conn.executemany("INSERT INTO staging_trips VALUES (?)", [(d,) for d in staging_dates])
+        conn.executemany(
+            "INSERT INTO mart_daily_summary VALUES (?, 10, 1, 1, 1, 1, 1, 1)",
+            [(d,) for d in staging_dates],
+        )
+        return conn
+
+    def test_cutoff_uses_raw_business_date(self):
+        conn = self.make_pipeline()
+
+        CREATE_DB.plant_staleness(conn)
+
+        raw_max = conn.execute(
+            "SELECT MAX(DATE(tpep_pickup_datetime)) FROM raw_trips"
+        ).fetchone()[0]
+        staging_max = conn.execute(
+            "SELECT MAX(trip_date) FROM staging_trips"
+        ).fetchone()[0]
+        mart_max = conn.execute(
+            "SELECT MAX(trip_date) FROM mart_daily_summary"
+        ).fetchone()[0]
+        self.assertEqual(raw_max, "2026-01-10")
+        self.assertEqual(staging_max, "2026-01-07")
+        self.assertEqual(mart_max, "2026-01-07")
+
+    def test_empty_load_uses_an_existing_mart_date(self):
+        conn = self.make_pipeline()
+
+        CREATE_DB.plant_staleness(conn)
+
+        empty_days = conn.execute(
+            "SELECT COUNT(*) FROM mart_daily_summary WHERE trip_count = 0"
+        ).fetchone()[0]
+        self.assertEqual(empty_days, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

The committed `nyc_taxi_pipeline.db` does not currently contain the two
freshness signals described by its README: the observable stage lag is nine
calendar days rather than three, and no mart row has `trip_count = 0`.

This change makes the generator deterministic for the sparse 250k-row sample:

- derive the cutoff from the raw pickup business timestamp instead of the
  staging table that is about to be truncated;
- plant the empty load on an existing median mart date instead of assuming
  `cutoff - 7 days` exists;
- report the actual post-cutoff lag, which can exceed the three-day target when
  sampled dates are sparse;
- regenerate the committed pipeline database and update the README with its
  observed dates; and
- add focused stdlib regression tests for the raw-date cutoff and guaranteed
  empty-load row.

The regenerated committed artifact has:

| Signal | Value |
| --- | --- |
| Raw max business date | `2016-03-10` |
| Staging max business date | `2016-03-01` |
| Mart max business date | `2016-03-01` |
| Observable stage lag | 9 calendar days |
| Empty-load mart date | `2015-01-21` |
| Empty-load `trip_count` | `0` |

The cutoff target is still raw max minus three calendar days (`2016-03-07`).
The observable lag is nine days because the committed sample has no rows from
March 2 through March 7. The README now makes that distinction explicit.

The approximately 86.5 MiB generated database is intentionally included in
this patch. This repository already tracks the generated NYC Taxi artifacts,
and its README directs demo users to the committed pipeline database. Updating
only the generator would leave the default download/demo path with the broken
signals reported in #219 and #222. The clean `nyc_taxi.db` source artifact is
unchanged.

Closes #219.
Closes #222.

### Verification

```bash
python3 -m unittest -v tests/test_nyc_taxi_create_db.py
```

```text
Ran 2 tests in 0.010s
OK
```

```bash
cd datasets/nyc-taxi
python3 create_db.py --pipeline-from-existing
```

```text
Raw data through: 2016-03-10
Staging/mart cutoff target: 2016-03-07 (3 calendar days)
Observed staging max: 2016-03-01 (9 calendar days behind raw)
Empty load: 2015-01-21 shows 0 trips
```

```sql
SELECT MAX(DATE(tpep_pickup_datetime)) FROM raw_trips;
SELECT MAX(trip_date) FROM staging_trips;
SELECT MAX(trip_date) FROM mart_daily_summary;
SELECT trip_date, trip_count
FROM mart_daily_summary
WHERE trip_count = 0;
```

```text
2016-03-10
2016-03-01
2016-03-01
2015-01-21|0
```

### Scope

This changes only the NYC Taxi dataset generator, its focused regression test,
the generated planted database, and the corresponding README section. It does
not change the clean `nyc_taxi.db` source artifact or any DataHub service.
